### PR TITLE
Add RemoveMerchandise method and update menu options

### DIFF
--- a/VerifonePayment.Lib/VerifonePayment.cs
+++ b/VerifonePayment.Lib/VerifonePayment.cs
@@ -250,6 +250,33 @@ namespace VerifonePayment.Lib
         }
 
         /// <summary>
+        /// Remove merchandise.
+        /// </summary>
+        public void RemoveMerchandise()
+        {
+            var basket_manager = payment_sdk_.TransactionManager.BasketManager;
+            var basket = basket_manager.Basket;
+            IList<Merchandise> merchandise_list = new List<Merchandise>();
+            if (basket != null)
+            {
+                merchandise_list = basket.Merchandise;
+            }
+            if (merchandise_list.Count > 0)
+            {
+                var merchandise = merchandise_list[merchandise_list.Count - 1];
+                var amount = merchandise.Amount;
+                var amount_totals = basket_manager.CurrentAmountTotals;
+                if (amount_totals != null)
+                {
+                    amount_totals.SubtractAmounts(amount, new VerifoneSdk.Decimal(0), new VerifoneSdk.Decimal(0),
+                       new VerifoneSdk.Decimal(0), new VerifoneSdk.Decimal(0), new VerifoneSdk.Decimal(0), amount);
+                    var removed = new List<Merchandise>(); removed.Add(merchandise);
+                    basket_manager.RemoveMerchandise(removed, amount_totals);
+                }
+            }
+        }
+
+        /// <summary>
         /// Payment transaction.
         /// </summary>
         /// <param name="total">The total amount.</param>

--- a/VerifonePayment.Test/Program.cs
+++ b/VerifonePayment.Test/Program.cs
@@ -19,7 +19,7 @@ namespace VerifonePayment.Test
         {
             try
             {
-                var verifonePayment = new Lib.VerifonePayment("192.168.80.51");
+                var verifonePayment = new Lib.VerifonePayment("192.168.40.173");
 
                 // Subscribe to the event
                 verifonePayment.StatusEventOccurred += VerifonePayment_StatusEventOccurred;
@@ -40,9 +40,10 @@ namespace VerifonePayment.Test
                     Console.WriteLine("3. StartSession");
                     Console.WriteLine("4. AddMerchandise");
                     Console.WriteLine("5. PaymentTransaction");
-                    Console.WriteLine("6. EndSession");
-                    Console.WriteLine("7. TearDown");
-                    Console.WriteLine("8. Exit");
+                    Console.WriteLine("6. RemoveMerchandise");
+                    Console.WriteLine("7. EndSession");
+                    Console.WriteLine("8. TearDown");
+                    Console.WriteLine("9. Exit");
 
                     switch (Console.ReadLine())
                     {
@@ -72,15 +73,20 @@ namespace VerifonePayment.Test
                             break;
 
                         case "6":
+                            verifonePayment.RemoveMerchandise();
+                            WaitForEvent(basketEventStatusEventReceived, "RemoveMerchandise");
+                            break;
+
+                        case "7":
                             verifonePayment.EndSession();
                             WaitForEvent(statusEventReceived, "EndSession");
                             break;
-                        case "7":
+                        case "8":
                             verifonePayment.TearDown();
                             WaitForEvent(statusEventReceived, "TearDown");
                             break;
 
-                        case "8":
+                        case "9":
                             running = false;
                             break;
 


### PR DESCRIPTION
A new `RemoveMerchandise` method was added to the `VerifonePayment.Lib` namespace in `VerifonePayment.cs`. This method removes the last merchandise item from the basket, updates the amount totals, and reflects the changes in the basket manager.

In `Program.cs`:
- Updated the IP address for initializing `VerifonePayment`.
- Added a new menu option "6. RemoveMerchandise" and renumbered subsequent options.
- Implemented a new case in the `switch` statement to handle the "RemoveMerchandise" operation.